### PR TITLE
An important fix: the reference frame while computing strain

### DIFF
--- a/compute_strain.py
+++ b/compute_strain.py
@@ -766,7 +766,7 @@ if __name__=='__main__':
     FT = float(sys.argv[2])
     OF = int(sys.argv[3])
     CF = int(sys.argv[4])
-    refN = int(sys.argv[5])
+    refN = OF-1 #int(sys.argv[5])
         
     print("Computing root strain")
     print("Frame time:",FT)


### PR DESCRIPTION
The reference frame (refN) in compute_strain.py should be calculated from the opening frame number (OF), and not from the manual segmentation frame. This has been updated.